### PR TITLE
feat: enhance outliner document management with query invalidation

### DIFF
--- a/frontend/src/hooks/useOutlinerDocument.ts
+++ b/frontend/src/hooks/useOutlinerDocument.ts
@@ -282,6 +282,8 @@ export const useOutlinerDocument = (options?: UseOutlinerDocumentOptions) => {
       
       // Refetch to ensure consistency with server state (in case server made different changes)
       queryClient.invalidateQueries({ queryKey: ['outliner-document', documentId] });
+      // Also invalidate documents list so Dashboard shows updated segment counts
+      queryClient.invalidateQueries({ queryKey: ['outliner-documents'] });
       toast.success('Segment split successfully');
     },
   });
@@ -306,6 +308,8 @@ export const useOutlinerDocument = (options?: UseOutlinerDocumentOptions) => {
       });
       // Only update UI on success
       queryClient.invalidateQueries({ queryKey: ['outliner-document', documentId] });
+      // Also invalidate documents list so Dashboard shows updated segment counts
+      queryClient.invalidateQueries({ queryKey: ['outliner-documents'] });
       toast.success('Segments merged successfully');
     },
     onError: (error: Error, segmentIds) => {
@@ -484,6 +488,8 @@ export const useOutlinerDocument = (options?: UseOutlinerDocumentOptions) => {
     onSuccess: () => {
       // Refetch to ensure consistency with server state
       queryClient.invalidateQueries({ queryKey: ['outliner-document', documentId] });
+      // Also invalidate documents list so Dashboard shows updated segment counts
+      queryClient.invalidateQueries({ queryKey: ['outliner-documents'] });
       toast.success('Segments reset successfully');
     },
   });
@@ -570,6 +576,8 @@ export const useOutlinerDocument = (options?: UseOutlinerDocumentOptions) => {
     onSuccess: (data) => {
       // Refetch to ensure consistency with server state (server IDs will replace temp IDs)
       queryClient.invalidateQueries({ queryKey: ['outliner-document', documentId] });
+      // Also invalidate documents list so Dashboard shows updated segment counts
+      queryClient.invalidateQueries({ queryKey: ['outliner-documents'] });
       toast.success(`Created ${data.length} segment${data.length > 1 ? 's' : ''} successfully`);
     },
   });

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -110,7 +110,7 @@ const OutlinerUpload: React.FC = () => {
        
                 <Button 
               onClick={assignWork}
-              disabled={assignWorkMutation.isPending || !userId }
+              disabled={assignWorkMutation.isPending || !userId || documents.some(doc => doc.status === 'active' && doc.checked_segments < doc.total_segments)}
             >
               {assignWorkMutation.isPending ? 'Assigning...' : 'Assign me a work'}
             </Button>


### PR DESCRIPTION
- Added query invalidation for the documents list in the `useOutlinerDocument` hook to ensure the Dashboard reflects updated segment counts after segment operations.
- Updated the `assignWork` button in the Dashboard to disable when active documents have unchecked segments, improving user experience and preventing invalid actions.